### PR TITLE
Update GeocodeParser.js

### DIFF
--- a/src/GeocodeParser.js
+++ b/src/GeocodeParser.js
@@ -72,7 +72,7 @@ class GeocodeParser {
     const geo = this.getGeo();
     
     if (geo && geo.location) {
-      return geo.location.lat;
+      return geo.location.lat();
     }
     
     return null;
@@ -82,7 +82,7 @@ class GeocodeParser {
     const geo = this.getGeo();
     
     if (geo && geo.location) {
-      return geo.location.lng;
+      return geo.location.lng();
     }
     
     return null;


### PR DESCRIPTION
`geo.location.lat` and `geo.location.lng` are coming back as functions. Returning invoked function to get correct result.